### PR TITLE
🐛 Fix: Use latest npm version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
 .nyc_output
+.vscode
 
 *.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ COPY package*.json ./
 RUN apt-get update
 RUN apt-get -y install git
 
+RUN npm install -g npm@latest
 RUN npm ci --only=production
 
 


### PR DESCRIPTION
This GHA failed when I released web yesterday: https://github.com/8fit/publizist-frontend-gatsby/runs/1327607896
Rerunning the task didn't help.

The error originates from this line:
https://github.com/8fit/gha-version-bump/blob/7de5125597f3d1dd277bc6d94affbaef50ed6d29/Dockerfile#L29

```sh
npm notice 
npm notice New patch version of npm available! 7.0.3 -> 7.0.6
npm notice Changelog: <https://github.com/npm/cli/releases/tag/v7.0.6>
npm notice Run `npm install -g npm@7.0.6` to update!
npm notice
```

So, the solution is upgrading npm within this Github Action.
In order to avoid doing that whenever npm decides to release a new patch version I'm updating to `npm@latest`.

Once this is merged auto-bumping the version on web should work again (see here: https://github.com/8fit/publizist-frontend-gatsby/runs/1327831130)